### PR TITLE
Handle if JSON is not filled yet

### DIFF
--- a/custom_components/formulaone_api/constructorsensor.py
+++ b/custom_components/formulaone_api/constructorsensor.py
@@ -16,11 +16,15 @@ class ConstructorsSensor(FormulaOneSensor):
 
         now = dt.now()
         constructors = f1.constructor_standings(season=now.year).json
+        if constructors['MRData']['total'] == "0":
+            data = "Not yet available"
+        else:
+            data = constructors['MRData']['StandingsTable']['StandingsLists'][0]['ConstructorStandings']
 
         # # Merge all attributes to a single dict.
         all_attr = {
             'last_update': now,
-            'data': constructors['MRData']['StandingsTable']['StandingsLists'][0]['ConstructorStandings']
+            'data': data
         }
 
         return all_attr

--- a/custom_components/formulaone_api/constructorsensor.py
+++ b/custom_components/formulaone_api/constructorsensor.py
@@ -17,7 +17,7 @@ class ConstructorsSensor(FormulaOneSensor):
         now = dt.now()
         constructors = f1.constructor_standings(season=now.year).json
         if constructors['MRData']['total'] == "0":
-            data = "Not yet available"
+            data = []
         else:
             data = constructors['MRData']['StandingsTable']['StandingsLists'][0]['ConstructorStandings']
 

--- a/custom_components/formulaone_api/driverssensor.py
+++ b/custom_components/formulaone_api/driverssensor.py
@@ -17,7 +17,7 @@ class DriversSensor(FormulaOneSensor):
         now = dt.now()        
         drivers = f1.driver_standings(season=now.year).json
         if drivers['MRData']['total'] == "0":
-            data = "Not yet available"
+            data = []
         else:
             data = drivers['MRData']['StandingsTable']['StandingsLists'][0]['DriverStandings']
 

--- a/custom_components/formulaone_api/driverssensor.py
+++ b/custom_components/formulaone_api/driverssensor.py
@@ -16,11 +16,16 @@ class DriversSensor(FormulaOneSensor):
 
         now = dt.now()        
         drivers = f1.driver_standings(season=now.year).json
+        if drivers['MRData']['total'] == "0":
+            data = "Not yet available"
+        else:
+            data = drivers['MRData']['StandingsTable']['StandingsLists'][0]['DriverStandings']
+
 
         # # Merge all attributes to a single dict.
         all_attr = {
             'last_update': now,
-            'data': drivers['MRData']['StandingsTable']['StandingsLists'][0]['DriverStandings']
+            'data': data
         }
 
         return all_attr


### PR DESCRIPTION
The Drivers and Constructors JSON for 2023 do not contain data yet, making the component error out. The JSON does tell you it has a total of 0 results in it, so we use it.

```json
{"MRData":{"xmlns":"http:\/\/ergast.com\/mrd\/1.5","series":"f1","url":"http://ergast.com/api/f1/2023/constructorstandings.json","limit":"30","offset":"0","total":"0","StandingsTable":{"season":"2023","StandingsLists":[]}}}

{"MRData":{"xmlns":"http:\/\/ergast.com\/mrd\/1.5","series":"f1","url":"http://ergast.com/api/f1/2023/driverstandings.json","limit":"30","offset":"0","total":"0","StandingsTable":{"season":"2023","StandingsLists":[]}}}
```

Fixes #66 