### PR TITLE
Fix for season start

### DIFF
--- a/custom_components/formulaone_api/racessensor.py
+++ b/custom_components/formulaone_api/racessensor.py
@@ -16,7 +16,7 @@ class RacesSensor(FormulaOneSensor):
         f1 = F1()
 
         now = dt.now()
-        races = f1.current_schedule().json
+        races = f1.season_schedule(season=now.year).json
         next_race = None
 
         found = False


### PR DESCRIPTION
`current.json` is still returning the 2022 season, while `2023.json` perfectly shows the 2023 season information.